### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.ktouch.json
+++ b/org.kde.ktouch.json
@@ -11,6 +11,15 @@
         "--socket=wayland",
         "--socket=x11"
     ],
+     "cleanup": [
+        "/include",
+        "/lib/cmake",
+        "/lib/pkgconfig",
+        "/share/doc",
+        "/share/man",
+        "*.la",
+        "*.a"
+    ],
     "modules": [
         {
             "name": "libxkbfile",


### PR DESCRIPTION
The installed size reduced from 8.8 MB to 4.4 MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.